### PR TITLE
Replace formulajs with @formulajs/formulajs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
  */
 
 const _ = require('lodash')
-const formula = require('formulajs')
+const formula = require('@formulajs/formulajs')
 const staticEval = require('static-eval')
 const esprima = require('esprima')
 const assert = require('@balena/jellyfish-assert')

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,15 @@
         }
       }
     },
+    "@formulajs/formulajs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@formulajs/formulajs/-/formulajs-2.4.3.tgz",
+      "integrity": "sha512-i+va0JJYyb0E9VlsJ0iHaVu7DoiJ+Vx/63QXIj3uHLMmBp2rJOfGXaWyhQyO06yBV+l8oCd85QA9STASV1XeVQ==",
+      "requires": {
+        "bessel": "^1.0.2",
+        "jstat": "^1.9.2"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -468,12 +477,9 @@
       "dev": true
     },
     "bessel": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/bessel/-/bessel-0.2.0.tgz",
-      "integrity": "sha1-E8s5zSkjMhnsLacl4LoMZvtGtvI=",
-      "requires": {
-        "voc": "^1.2.0"
-      }
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bessel/-/bessel-1.0.2.tgz",
+      "integrity": "sha512-Al3nHGQGqDYqqinXhQzmwmcRToe/3WyBv4N8aZc5Pef8xw2neZlR9VPi84Sa23JtgWcucu18HxVZrnI0fn2etw=="
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -1071,11 +1077,6 @@
         }
       }
     },
-    "diff": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
-      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY="
-    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1647,11 +1648,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1789,17 +1785,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
-    },
-    "formulajs": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/formulajs/-/formulajs-1.0.8.tgz",
-      "integrity": "sha1-jDXRZPNopf+xp6vPUHXPjeXmBw4=",
-      "requires": {
-        "bessel": "0.2.0",
-        "jStat": "1.0.6",
-        "numeral": "1.5.3",
-        "numeric": "1.2.6"
-      }
     },
     "fs-then-native": {
       "version": "2.0.0",
@@ -2251,15 +2236,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "jStat": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.0.6.tgz",
-      "integrity": "sha1-s3gEubS27+f94A0wj9aZr8lx1Vg=",
-      "requires": {
-        "uglify-js": "1.2.3",
-        "vows": "0.7.x"
-      }
-    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -2423,6 +2399,11 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "jstat": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/jstat/-/jstat-1.9.3.tgz",
+      "integrity": "sha512-/2JL4Xv6xfhN2+AEKQGTYr1LZTmBCR/5fHxJVvb9zWNsmKZfKrl3wYYK8SD/Z8kXkf+ZSusfumLZ4wDTHrWujA=="
     },
     "keyv": {
       "version": "3.1.0",
@@ -2807,16 +2788,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true
-    },
-    "numeral": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/numeral/-/numeral-1.5.3.tgz",
-      "integrity": "sha1-pMPrpoI5WAUJ+BgmfHckO85D/2I="
-    },
-    "numeric": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
-      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao="
     },
     "object-get": {
       "version": "2.1.1",
@@ -4071,11 +4042,6 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
-    "uglify-js": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.3.tgz",
-      "integrity": "sha1-OwzmYxoo3KpkMCuJMSOyCHa9xTY="
-    },
     "underscore": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
@@ -4156,20 +4122,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "voc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/voc/-/voc-1.2.0.tgz",
-      "integrity": "sha512-BOuDjFFYvJdZO6e/N65AlaDItXo2TgyLjeyRYcqgAPkXpp5yTJcvkL2n+syO1r9Qc5g96tfBD2tuiMhYDmaGcA=="
-    },
-    "vows": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
-      "integrity": "sha1-3QBl8RC6DAptY+hEhRwyCBdtWGc=",
-      "requires": {
-        "diff": "~1.0.3",
-        "eyes": ">=0.1.6"
       }
     },
     "walk-back": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@balena/jellyfish-assert": "0.0.18",
+    "@formulajs/formulajs": "^2.4.3",
     "esprima": "^4.0.1",
-    "formulajs": "^1.0.8",
     "lodash": "^4.17.19",
     "object-hash": "^2.0.3",
     "static-eval": "^2.1.0"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Replace [`formulajs`](https://www.npmjs.com/package/formulajs) dependency with [`@formulajs/formulajs`](https://www.npmjs.com/package/@formulajs/formulajs) as the former hasn't been updated in four years and depends on packages that have security vulnerabilities.