### PR TITLE
Update checkForSpecialCases to findSpecialCases since we need to find the action based on the special case

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,8 @@ const assert = require('@balena/jellyfish-assert')
 const card = require('./card')
 const formula = require('./formula')
 const {
-	checkForSpecialCases
+	findSpecialCases,
+	getActionForSpecialCase
 } = require('./special-cases')
 
 /**
@@ -133,7 +134,7 @@ exports.getTypeTriggers = (typeCard) => {
 	for (const path of card.getFormulasPaths(typeCard.data.schema)) {
 		const ast = esprima.parse(path.formula).body[0].expression
 
-		const specialCase = checkForSpecialCases(ast)
+		const specialCase = findSpecialCases(ast)
 		if (specialCase) {
 			const literal = ast.arguments[1] || ast.arguments[0].arguments[1]
 			const arg = runAST(literal, {
@@ -142,6 +143,8 @@ exports.getTypeTriggers = (typeCard) => {
 			})
 
 			const valueProperty = `source.${arg}`
+
+			const action = getActionForSpecialCase(specialCase)
 
 			triggers.push({
 				slug: slugify(`triggered-action-${typeCard.slug}-${path.output.join('-')}`),
@@ -155,7 +158,7 @@ exports.getTypeTriggers = (typeCard) => {
 				tags: [],
 				data: {
 					async: true,
-					action: 'action-set-add@1.0.0',
+					action,
 					type: `${typeCard.slug}@${typeCard.version}`,
 					target: {
 						$eval: 'source.links[\'is attached to\'][0].id'

--- a/lib/special-cases.js
+++ b/lib/special-cases.js
@@ -4,6 +4,13 @@
  * Proprietary and confidential.
  */
 
+const _ = require('lodash')
+
+const specialCases = {
+	DATE_VALUE: 'DATE_VALUE',
+	AGGREGATE: 'AGGREGATE'
+}
+
 /**
  * Checks whether the supplied expression is a call expression, called by an identifier
  *
@@ -57,7 +64,7 @@ const checkBasics = (type, callee, arg) => {
  *               }])
  */
 const usesDateValue = (type, callee, args) => {
-	const isDateValueFormula = callee.name === 'DATE_VALUE'
+	const isDateValueFormula = callee.name === specialCases.DATE_VALUE
 
 	if (isDateValueFormula && isCallExpression(type, callee)) {
 		return true
@@ -65,9 +72,12 @@ const usesDateValue = (type, callee, args) => {
 
 	// Checks to see if the next formula is DATE_VALUE
 	// (in the event of a MIN or MAX being applied)
-	const firstArg = args[0]
+	const firstArg = _.get(args, [ 0 ])
+	if (!firstArg || !firstArg.arguments) {
+		return false
+	}
 	const passesBasicChecks = checkBasics(firstArg.type, firstArg.callee, firstArg.arguments[0])
-	return passesBasicChecks && firstArg.callee.name === 'DATE_VALUE'
+	return passesBasicChecks && firstArg.callee.name === specialCases.DATE_VALUE
 }
 
 /**
@@ -77,7 +87,7 @@ const usesDateValue = (type, callee, args) => {
  * @param {String} root0.type - The type of expression (should be 'CallExpression')
  * @param {Object} root0.callee - An object describing the expression caller
  * @param {List} root0.arguments - Arguments passed to the expression
- * @returns {Boolean}
+ * @returns {String} - representing the formula that matches our special case
  * @example
  *
  * checkForSpecialCases({
@@ -89,15 +99,37 @@ const usesDateValue = (type, callee, args) => {
  *   }]
  * })
  */
-exports.checkForSpecialCases = ({
+exports.findSpecialCases = ({
 	type, callee, arguments: args
 }) => {
 	const passesBasicChecks = checkBasics(type, callee, args[0])
-	const usesAggregate = callee.name === 'AGGREGATE'
+	const usesAggregate = callee.name === specialCases.AGGREGATE
 
 	if (passesBasicChecks && usesAggregate) {
-		return true
+		return specialCases.AGGREGATE
 	}
 
-	return usesDateValue(type, callee, args)
+	if (usesDateValue(type, callee, args)) {
+		return specialCases.DATE_VALUE
+	}
+	return null
+}
+
+/**
+ * Finds the action needed for the special case
+ *
+ * @param {Sting} specialCase - A string representing the formula of our special case
+ * @returns {String} - the action type our trigger needs to run for the formula
+ * @example
+ *
+ * getActionForSpecialCase(AGGREGATE)
+ */
+exports.getActionForSpecialCase = (specialCase) => {
+	switch (specialCase) {
+		case specialCases.AGGREGATE:
+			return 'action-set-add@1.0.0'
+		case specialCases.DATE_VALUE:
+		default:
+			return 'action-set-update@1.0.0'
+	}
 }

--- a/lib/tests/get-type-triggers.spec.js
+++ b/lib/tests/get-type-triggers.spec.js
@@ -127,7 +127,7 @@ ava('.getTypeTriggers() should return a sensible trigger when running DATE_VALUE
 			data: {
 				async: true,
 				type: 'thread@1.0.0',
-				action: 'action-set-add@1.0.0',
+				action: 'action-set-update@1.0.0',
 				target: {
 					$eval: 'source.links[\'is attached to\'][0].id'
 				},
@@ -186,7 +186,7 @@ ava('.getTypeTriggers() should still return a sensible trigger when running MAX 
 						type: 'object',
 						properties: {
 							latest_event_created_at: {
-								type: 'number',
+								type: 'string',
 								$$formula: 'MAX(DATE_VALUE($events, "created_at"))'
 							}
 						}
@@ -210,7 +210,7 @@ ava('.getTypeTriggers() should still return a sensible trigger when running MAX 
 			data: {
 				async: true,
 				type: 'thread@1.0.0',
-				action: 'action-set-add@1.0.0',
+				action: 'action-set-update@1.0.0',
 				target: {
 					$eval: 'source.links[\'is attached to\'][0].id'
 				},


### PR DESCRIPTION
Also adds a helper for retrieving the action and adds a check to the checkForDateValue function to make sure
the arg exists (I was seeing some errors with this when running this on the worker locally)

Change-type: patch
Signed-off-by: Lucy-Jane Walsh <lucy-jane@balena.io>