### PR TITLE
Remove eslint-plugin-standard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@balena/jellyfish-jellyscript",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "UNLICENSED",
       "dependencies": {
         "@balena/jellyfish-assert": "^1.0.20",
@@ -29,7 +29,6 @@
         "eslint-plugin-lodash": "^7.1.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.2.1",
-        "eslint-plugin-standard": "^4.0.2",
         "husky": "^4.3.0",
         "jsdoc-to-markdown": "^6.0.1",
         "lint-staged": "^10.5.1"
@@ -2506,6 +2505,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
       }
@@ -9015,6 +9015,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.2.tgz",
       "integrity": "sha512-nKptN8l7jksXkwFk++PhJB3cCDTcXOEyhISIN86Ue2feJ1LFyY3PrY3/xT2keXlJSY5bpmbiTG0f885/YKAvTA==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "eslint-plugin-lodash": "^7.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.2",
     "husky": "^4.3.0",
     "jsdoc-to-markdown": "^6.0.1",
     "lint-staged": "^10.5.1"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

The `eslint-config-standard` major bump to v16 is causing the following lint error:
```
npx depcheck --ignore-bin-package
Unused devDependencies
* eslint-plugin-standard
make: *** [Makefile:42: lint] Error 255
npm ERR! Test failed.  See above for more details.
```

Lint is passing without having `eslint-plugin-standard` installed. Found these `eslint-config-standard` changes that may be related:
- https://github.com/standard/eslint-config-standard/commit/0f4d3f2fb91e55d13548736f4bf4b639e2ee1a57
- https://github.com/standard/standard/issues/1316