### PR TITLE
Evaluate all fields when patching a card

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@
  */
 
 const _ = require('lodash')
+const jsonpatch = require('fast-json-patch')
 const formula = require('@formulajs/formulajs')
 const staticEval = require('static-eval')
 const esprima = require('esprima')
@@ -71,45 +72,13 @@ const getDefaultValueForType = (type) => {
 }
 
 exports.evaluatePatch = (schema, object, patch) => {
-	const paths = card.getFormulasPaths(schema).reduce((accumulator, path) => {
-		accumulator[`/${path.output.join('/')}`] = path
-		return accumulator
-	}, {})
-
-	for (const operation of patch) {
-		if (operation.op === 'test' ||
-			operation.op === 'remove' ||
-			!paths[operation.path]) {
-			continue
-		}
-
-		if (operation.op === 'copy' || operation.op === 'move') {
-			const source = _.get(object, operation.from.split('/').slice(1))
-			const result = exports.evaluate(paths[operation.path].formula, {
-				input: source,
-				context: object
-			})
-
-			if (!_.isNull(result.value)) {
-				Reflect.deleteProperty(operation, 'from')
-				operation.op = 'replace'
-				operation.value = result.value
-			}
-
-			continue
-		}
-
-		const result = exports.evaluate(paths[operation.path].formula, {
-			input: operation.value,
-			context: object
-		})
-
-		if (!_.isNull(result.value)) {
-			operation.value = result.value
-		}
-	}
-
-	return patch
+	// The patch may affect other evaluated fields on the card.
+	// Generate a patched object and evaluate it. Then compare it to the original
+	// object to get a final list of patches to apply.
+	const patchedObject = jsonpatch.applyPatch(object, patch, false, false).newDocument
+	const evaluatedPatchedObject = exports.evaluateObject(schema, patchedObject)
+	const allPatches = jsonpatch.compare(object, evaluatedPatchedObject)
+	return allPatches
 }
 
 exports.evaluateObject = (schema, object) => {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -277,6 +277,73 @@ ava('.evaluateObject() should not do anything if the schema has no formulas', as
 	})
 })
 
+ava('.evaluatePatch() should evaluate a patched field', async (test) => {
+	const patch = [
+		{
+			op: 'replace',
+			path: '/foo',
+			value: 'new'
+		}
+	]
+	const expectedPatch = [
+		{
+			op: 'replace',
+			path: '/foo',
+			value: 'NEW'
+		}
+	]
+	const result = jellyscript.evaluatePatch({
+		type: 'object',
+		properties: {
+			foo: {
+				type: 'string',
+				$$formula: 'UPPER(input)'
+			}
+		}
+	}, {
+		foo: 'old'
+	}, patch)
+	test.deepEqual(result, expectedPatch)
+})
+
+ava('.evaluatePatch() should evaluate all formula fields', async (test) => {
+	const patch = [
+		{
+			op: 'replace',
+			path: '/bar',
+			value: 4
+		}
+	]
+	const expectedPatch = [
+		{
+			op: 'replace',
+			path: '/bar',
+			value: 4
+		},
+		{
+			op: 'replace',
+			path: '/foo',
+			value: 8
+		}
+	]
+	const result = jellyscript.evaluatePatch({
+		type: 'object',
+		properties: {
+			foo: {
+				type: 'number',
+				$$formula: 'this.bar * 2'
+			},
+			bar: {
+				type: 'number'
+			}
+		}
+	}, {
+		foo: 2,
+		bar: 2
+	}, patch)
+	test.deepEqual(result, expectedPatch)
+})
+
 ava('.getTypeTriggers() should report back watchers when aggregating events', async (test) => {
 	const triggers = jellyscript.getTypeTriggers({
 		slug: 'thread',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2200,6 +2200,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "fast-json-patch": {
+      "version": "3.0.0-1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@balena/jellyfish-assert": "^1.0.29",
     "@formulajs/formulajs": "^2.6.1",
     "esprima": "^4.0.1",
+    "fast-json-patch": "^3.0.0-1",
     "lodash": "^4.17.20",
     "object-hash": "^2.0.3",
     "static-eval": "^2.1.0"


### PR DESCRIPTION
The patch may affect other evaulated fields on the card. So we generate a patched object and evaluate it. Then we compare it to the original object to get a final list of patches to apply.

Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Closes https://github.com/product-os/jellyfish/issues/4653