### PR TITLE
Use link notation instead of $events keyword

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,11 +26,11 @@ formula.REGEX_MATCH = (regex, string) => {
 }
 
 formula.AGGREGATE = (list, func) => {
-	return Array.from(list.reduce((accumulator, element) => {
-		for (const value of func(element)) {
+	return Array.from((list || []).reduce((accumulator, element) => {
+		const values = func(element) || []
+		for (const value of values) {
 			accumulator.add(value)
 		}
-
 		return accumulator
 	}, new Set()))
 }
@@ -115,11 +115,10 @@ exports.evaluatePatch = (schema, object, patch) => {
 }
 
 exports.evaluateObject = (schema, object) => {
+	if (_.isEmpty(object)) {
+		return object
+	}
 	for (const path of card.getFormulasPaths(schema)) {
-		if (_.isEmpty(object)) {
-			continue
-		}
-
 		const input = _.get(object, path.output, getDefaultValueForType(path.type))
 
 		const result = exports.evaluate(path.formula, {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -107,6 +107,24 @@ ava('AGGREGATE: should aggregate a set of object properties', (test) => {
 	})
 })
 
+ava.only('AGGREGATE: treats references to objects not found as an empty array', (test) => {
+	const result = jellyscript.evaluate('AGGREGATE(input, PARTIAL(FLIP(PROPERTY), "mentions"))', {
+		context: {},
+		input: [
+			{
+				bar: [ 'foo' ]
+			},
+			{
+				bar: [ 'bar' ]
+			}
+		]
+	})
+
+	test.deepEqual(result, {
+		value: []
+	})
+})
+
 ava('REGEX_MATCH: should extract a set of mentions', (test) => {
 	const result = jellyscript.evaluate('REGEX_MATCH(/(@[a-zA-Z0-9-]+)/g, input)', {
 		context: {},


### PR DESCRIPTION
This will allow us to aggregate over any type of link, not just `is attached to`!

Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>