### PR TITLE
Use schedule instead of async in triggered actions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,7 @@ exports.getTypeTriggers = (typeCard) => {
 				markers: [],
 				tags: [],
 				data: {
-					async: true,
+					schedule: 'async',
 					action: 'action-set-add@1.0.0',
 					type: `${typeCard.slug}@${typeCard.version}`,
 					target: {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -312,7 +312,7 @@ ava('.getTypeTriggers() should report back watchers when aggregating events', as
 			links: {},
 			markers: [],
 			data: {
-				async: true,
+				schedule: 'async',
 				type: 'thread@1.0.0',
 				action: 'action-set-add@1.0.0',
 				target: {


### PR DESCRIPTION
Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Relates to: https://github.com/product-os/jellyfish-worker/pull/242