### PR TITLE
Add UNIQUE(FLATMAP()) as alternative to AGGREGATE

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,8 @@ const card = require('./card')
 formula.PARTIAL = _.partial
 formula.FLIP = _.flip
 formula.PROPERTY = _.get
+formula.FLATMAP = _.flatMap
+formula.UNIQUE = _.uniq
 
 formula.REGEX_MATCH = (regex, string) => {
 	return string.match(regex)
@@ -142,19 +144,70 @@ const slugify = (string) => {
 		.replace(/-{1,}/g, '-')
 }
 
+// Aggregating links is a special case. This is the expected base AST structure.
+// Note: this translates to a $$formula in the following format:
+// $$formula: 'UNIQUE(FLATMAP($events, "<SOURCE_PATH>"))'
+
+const LINKS_AGGREGATE_BASE_AST = {
+	type: 'CallExpression',
+	callee: {
+		type: 'Identifier',
+		name: 'AGGREGATE'
+	},
+	arguments: [
+		{
+			type: 'Identifier',
+			name: '$events'
+		},
+		{
+			// "value": "<SOURCE_PATH>",
+			// "raw": "'<SOURCE_PATH>'",
+			type: 'Literal'
+		}
+	]
+}
+
+const LINKS_UNIQUE_FLATMAP_BASE_AST = {
+	type: 'CallExpression',
+	callee: {
+		type: 'Identifier',
+		name: 'UNIQUE'
+	},
+	arguments: [
+		{
+			type: 'CallExpression',
+			callee: {
+				type: 'Identifier',
+				name: 'FLATMAP'
+			},
+			arguments: [
+				{
+					type: 'Identifier',
+					name: '$events'
+				},
+				{
+					// "value": "<SOURCE_PATH>",
+					// "raw": "'<SOURCE_PATH>'",
+					type: 'Literal'
+				}
+			]
+		}
+	]
+}
+
 exports.getTypeTriggers = (typeCard) => {
 	const triggers = []
 
 	for (const path of card.getFormulasPaths(typeCard.data.schema)) {
 		const ast = esprima.parse(path.formula).body[0].expression
 
-		// Aggregating over $events is a special case
-		if (ast.type === 'CallExpression' &&
-				ast.callee.type === 'Identifier' &&
-				ast.callee.name === 'AGGREGATE' &&
-				ast.arguments[0].type === 'Identifier' &&
-				ast.arguments[0].name === '$events') {
-			const arg = runAST(ast.arguments[1], {
+		// Aggregating over links is a special case
+		if (_.isMatch(ast, LINKS_AGGREGATE_BASE_AST) ||
+				_.isMatch(ast, LINKS_UNIQUE_FLATMAP_BASE_AST)) {
+			const literal = ast.callee.name === 'AGGREGATE'
+				? ast.arguments[1]
+				: ast.arguments[0].arguments[1]
+			const arg = runAST(literal, {
 				context: {},
 				input: {}
 			})

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -58,14 +58,22 @@ ava('.evaluate(): should access other properties from the card', (test) => {
 	})
 })
 
-ava('.evaluate(): should evaluate a function', (test) => {
-	const result = jellyscript.evaluate('FLIP(POW)', {
+ava('UNIQUE(FLATMAP()): should aggregate a set of object properties', (test) => {
+	const result = jellyscript.evaluate('UNIQUE(FLATMAP(input, "mentions"))', {
 		context: {},
-		input: 0
+		input: [
+			{
+				mentions: [ 'foo', 'bar' ]
+			},
+			{
+				mentions: [ 'bar' ]
+			}
+		]
 	})
 
-	test.is(result.value(2, 2), 4)
-	test.is(result.value(3, 2), 8)
+	test.deepEqual(result, {
+		value: [ 'foo', 'bar' ]
+	})
 })
 
 ava('AGGREGATE: should ignore duplicates', (test) => {
@@ -292,6 +300,89 @@ ava('.getTypeTriggers() should report back watchers when aggregating events', as
 							mentions: {
 								type: 'array',
 								$$formula: 'AGGREGATE($events, "data.mentions")'
+							}
+						}
+					}
+				}
+			}
+		}
+	})
+
+	test.deepEqual(triggers, [
+		{
+			type: 'triggered-action@1.0.0',
+			version: '1.0.0',
+			slug: 'triggered-action-thread-data-mentions',
+			requires: [],
+			capabilities: [],
+			active: true,
+			tags: [],
+			links: {},
+			markers: [],
+			data: {
+				schedule: 'async',
+				type: 'thread@1.0.0',
+				action: 'action-set-add@1.0.0',
+				target: {
+					$eval: 'source.links[\'is attached to\'][0].id'
+				},
+				arguments: {
+					property: 'data.mentions',
+					value: {
+						$if: 'source.data.mentions',
+						then: {
+							$eval: 'source.data.mentions'
+						},
+						else: []
+					}
+				},
+				filter: {
+					type: 'object',
+					$$links: {
+						'is attached to': {
+							type: 'object',
+							required: [ 'type' ],
+							properties: {
+								type: {
+									type: 'string',
+									const: 'thread@1.0.0'
+								}
+							}
+						}
+					},
+					required: [ 'data' ],
+					properties: {
+						data: {
+							type: 'object',
+							required: [ 'payload' ],
+							properties: {
+								payload: {
+									type: 'object'
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	])
+})
+
+ava('.getTypeTriggers() should report back watchers when aggregating events with UNIQUE and FLATMAP', async (test) => {
+	const triggers = jellyscript.getTypeTriggers({
+		slug: 'thread',
+		type: 'type@1.0.0',
+		version: '1.0.0',
+		data: {
+			schema: {
+				type: 'object',
+				properties: {
+					data: {
+						type: 'object',
+						properties: {
+							mentions: {
+								type: 'array',
+								$$formula: 'UNIQUE(FLATMAP($events, "data.mentions"))'
 							}
 						}
 					}


### PR DESCRIPTION
This change adds a simpler combination of UNIQUE and FLATMAP as an alternative to the custom AGGREGATE formulajs function.

Once we've updated card type definitions to use UNIQUE and FLATMAP and verified everything is working nicely, we can remove the AGGREGATE code.

I've also used lodash's `isMatch` function to more accurately/cleanly check for the 'special cases' of aggregating $events.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Before: `AGGREGATE($events, "tags")`
After: `UNIQUE(FLATMAP($events, "tags"))`
