### PR TITLE
Add 'contract' alias for 'this' evaluation variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,12 +46,13 @@
   "dependencies": {
     "@balena/jellyfish-assert": "^1.1.66",
     "@balena/jellyfish-client-sdk": "^5.4.1",
+    "@balena/jellyfish-logger": "^3.0.54",
     "@formulajs/formulajs": "2.6.10",
     "esprima": "^4.0.1",
     "fast-json-patch": "^3.0.0-1",
     "lodash": "^4.17.21",
-    "object-hash": "^2.2.0",
     "object-deep-search": "0.0.7",
+    "object-hash": "^2.2.0",
     "static-eval": "^2.1.0"
   },
   "devDependencies": {

--- a/repo.yml
+++ b/repo.yml
@@ -4,3 +4,5 @@ upstream:
     url: 'https://github.com/product-os/jellyfish-assert'
   - repo: 'jellycheck'
     url: 'https://github.com/product-os/jellycheck'
+  - repo: 'jellyfish-logger'
+    url: 'https://github.com/product-os/jellyfish-logger'


### PR DESCRIPTION
This is an intermediate step towards removing 'this' as a context
object when evaluating expressions using static-eval (as it causes
problems due to being a restricted keyword).

The next step will involve modifying the evaluate and evaluateObject
functions so that evaluate is not opinionated about naming context
variables.

In the meantime, we log a warning if the old 'this' reference is still
found in the code.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>