### PR TITLE
Remove unused schedule field from triggered-actions

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -632,7 +632,6 @@ test('.getTypeTriggers() should report back watchers when aggregating events', a
 			tags: [],
 			markers: [],
 			data: {
-				schedule: 'async',
 				type: 'thread@1.0.0',
 				action: 'action-set-add@1.0.0',
 				target: {
@@ -720,7 +719,6 @@ test('.getTypeTriggers() should report back watchers when aggregating events wit
 			tags: [],
 			markers: [],
 			data: {
-				schedule: 'async',
 				type: 'thread@1.0.0',
 				action: 'action-set-add@1.0.0',
 				target: {
@@ -861,7 +859,6 @@ test('.getTypeTriggers() should properly reverse links', async () => {
 			markers: [],
 			tags: [],
 			data: {
-				schedule: 'async',
 				action: 'action-update-card@1.0.0',
 				type: 'commit@1.0.0',
 				target: {
@@ -917,7 +914,6 @@ test('.getTypeTriggers() should properly reverse links', async () => {
 			markers: [],
 			tags: [],
 			data: {
-				schedule: 'async',
 				action: 'action-update-card@1.0.0',
 				type: 'commit@1.0.0',
 				target: {
@@ -951,7 +947,6 @@ test('.getTypeTriggers() should properly reverse links', async () => {
 			markers: [],
 			tags: [],
 			data: {
-				schedule: 'async',
 				action: 'action-update-card@1.0.0',
 				type: 'commit@1.0.0',
 				target: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -363,7 +363,6 @@ const createEventsTrigger = (
 		markers: [],
 		tags: [],
 		data: {
-			schedule: 'async',
 			action: 'action-set-add@1.0.0',
 			type: `${typeCard.slug}@${typeCard.version}`,
 			target: {
@@ -458,7 +457,6 @@ const createLinkTrigger = (
 				markers: [],
 				tags: [],
 				data: {
-					schedule: 'async',
 					action: 'action-update-card@1.0.0',
 					type: `${typeCard.slug}@${typeCard.version}`,
 					target: {


### PR DESCRIPTION
As of jellyfish-worker v7, action-requests generated from triggered
actions are always re-enqueued as new jobs and the `schedule` field is
no longer used. This change removes the redundant fields from the
triggered actions used for formula evaluation.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>