### PR TITLE
Add formulajs Renovate group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,10 @@
 {
   "extends": [
     "github>product-os/jellyfish-config//config/renovate"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["formulajs"]
+    }
   ]
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

The `formulajs` package is currently bringing in breaking changes that is blocking all Renovate non-major bump group PRs from automatically getting through. Will need to remove this new rule once we eventually merge in the latest version of `formulajs`.