### PR TITLE
fix: link-formulas didn't trigger on never-updated contracts

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -960,9 +960,7 @@ test('.getTypeTriggers() should properly reverse links', async () => {
 								'summary@1.0.0',
 							],
 						},
-						updated_at: {
-							type: 'string',
-						},
+						updated_at: true,
 					},
 				},
 			},
@@ -996,9 +994,7 @@ test('.getTypeTriggers() should properly reverse links', async () => {
 					},
 					properties: {
 						type: { type: 'string', enum: ['pull-request@1.0.0'] },
-						updated_at: {
-							type: 'string',
-						},
+						updated_at: true,
 					},
 				},
 			},
@@ -1035,9 +1031,7 @@ test('.getTypeTriggers() should properly reverse links', async () => {
 							type: 'string',
 							not: { enum: ['create@1.0.0', 'update@1.0.0', 'link@1.0.0'] },
 						},
-						updated_at: {
-							type: 'string',
-						},
+						updated_at: true,
 					},
 				},
 			},

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -491,9 +491,7 @@ const createLinkTrigger = (
 								type: 'string',
 								...typeFilter,
 							},
-							updated_at: {
-								type: 'string',
-							},
+							updated_at: true,
 						},
 					},
 				},


### PR DESCRIPTION
another reason why `updated_at` should be `NOT NULL`  🙈