### PR TITLE
Move typedoc to docs action

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,10 +23,8 @@ jobs:
         with:
           node-version: '14'
 
-      - name: Update .npmrc file with NPM Token
-        uses: dkershner6/use-npm-token-action@v1
-        with:
-          token: '${{ secrets.NPM_TOKEN }}'
+      - name: Install typedoc
+        run: npm i -g typedoc
 
       - name: Install NPM dependencies
         run: npm i

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "clean": "rimraf build",
     "build": "npm run clean && tsc -p tsconfig.build.json",
-    "lint": "balena-lint lib && npm run check && deplint && depcheck --ignore-bin-package --ignores=estree,json-schema,@types/jest,typedoc",
+    "lint": "balena-lint lib && npm run check && deplint && depcheck --ignore-bin-package --ignores=estree,json-schema,@types/jest",
     "lint:fix": "balena-lint --fix lib",
     "test": "npm run lint && npm run test:unit",
     "test:unit": "jest",
@@ -70,7 +70,6 @@
     "lint-staged": "^12.1.2",
     "simple-git-hooks": "^2.7.0",
     "ts-jest": "^27.0.7",
-    "typedoc": "^0.22.9",
     "typescript": "^4.4.4"
   },
   "simple-git-hooks": {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Try removing `typedoc` from dependencies as it often causes `npm install` to fail, usually every time `typescript` releases a new minor or major bump. I believe installing `typedoc` globally in the docs action should allow the docs action to do its job and permit us to remove `typedoc` from `devDependencies`, best of both worlds.