### PR TITLE
Bring back typedoc, pin typescript

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           node-version: '14'
 
-      - name: Install typedoc
-        run: npm i -g typedoc
-
       - name: Install NPM dependencies
         run: npm i
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "clean": "rimraf build",
     "build": "npm run clean && tsc -p tsconfig.build.json",
-    "lint": "balena-lint lib && npm run check && deplint && depcheck --ignore-bin-package --ignores=estree,json-schema,@types/jest",
+    "lint": "balena-lint lib && npm run check && deplint && depcheck --ignore-bin-package --ignores=estree,json-schema,@types/jest,typedoc,tslint",
     "lint:fix": "balena-lint --fix lib",
     "test": "npm run lint && npm run test:unit",
     "test:unit": "jest",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "lint-staged": "^12.1.2",
     "simple-git-hooks": "^2.7.0",
     "ts-jest": "^27.0.7",
-    "typescript": "^4.4.4"
+    "typedoc": "^0.22.9",
+    "typescript": "4.4.4"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"


### PR DESCRIPTION
Handle typedoc/typescript compatibility issue
by pinning typescript. Renovate will keep us
up to date anyway.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>