### PR TITLE
Switch to safe-eval

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -561,7 +561,7 @@ describe('.evaluateObject()', () => {
 									ORDER_BY(
 										FILTER(
 											contract.links["has attached element"],
-											function (c) { return c && (c.type === "message@1.0.0" || c.type === "whisper@1.0.0"); }
+											(c) => c.type === "message@1.0.0" || c.type === "whisper@1.0.0"
 										),
 										"data.timestamp"
 									)
@@ -624,7 +624,7 @@ describe('.evaluateObject()', () => {
 									ORDER_BY(
 										FILTER(
 											contract.links["has attached element"],
-											function (c) { return c && (c.type === "message@1.0.0" || c.type === "whisper@1.0.0"); }
+											(c) => c.type === "message@1.0.0" || c.type === "whisper@1.0.0"
 										),
 										"data.timestamp"
 									)
@@ -995,7 +995,7 @@ describe('NEEDS', () => {
 						type: 'string',
 						enum: ['never', 'pending', 'mergeable'],
 						$$formula:
-							'NEEDS(contract, "transformer-type", function (c) { return c && c.data.foo === "bar" })',
+							'NEEDS(contract, "transformer-type", (c) => c.data.foo === "bar")',
 					},
 				},
 			},
@@ -1050,7 +1050,7 @@ describe('NEEDS', () => {
 						type: 'string',
 						enum: ['never', 'pending', 'mergeable'],
 						$$formula:
-							'NEEDS(contract, "transformer-type", function (c) { return c && c.data.foo === "notbar" })',
+							'NEEDS(contract, "transformer-type", (c) => c.data.foo === "notbar")',
 					},
 				},
 			},
@@ -1105,7 +1105,7 @@ describe('NEEDS', () => {
 						type: 'string',
 						enum: ['never', 'pending', 'mergeable'],
 						$$formula:
-							'NEEDS(contract, "transformer-type", function (c) { return c && c.data.foo === "bar" })',
+							'NEEDS(contract, "transformer-type", (c) => c.data.foo === "bar")',
 					},
 				},
 			},
@@ -1156,7 +1156,7 @@ describe('NEEDS', () => {
 						type: 'string',
 						enum: ['never', 'pending', 'mergeable'],
 						$$formula:
-							'NEEDS(contract, "transformer-type", function (c) { return c && c.data.foo === "notbar" })',
+							'NEEDS(contract, "transformer-type", (c) => c.data.foo === "notbar")',
 					},
 				},
 			},
@@ -1459,7 +1459,7 @@ describe('.getTypeTriggers()', () => {
 												ORDER_BY(
 													FILTER(
 														contract.links["has attached element"],
-														function (c) { return c && (c.type === "message@1.0.0" || c.type === "whisper@1.0.0"); }
+														(c) => c.type === "message@1.0.0" || c.type === "whisper@1.0.0"
 													),
 													"data.timestamp"
 												)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,7 +13,7 @@ import formula from '@formulajs/formulajs';
 import type { JSONSchema7Object } from 'json-schema';
 import _, { Dictionary } from 'lodash';
 import * as objectDeepSearch from 'object-deep-search';
-import staticEval from 'static-eval';
+import safeEval from 'safe-eval';
 import { FormulaPath, getFormulasPaths } from './card';
 import { reverseLink } from './link-traversal';
 
@@ -125,8 +125,8 @@ export interface Options {
 	input: any;
 }
 
-const runAST = (ast: ESTree.Expression, evalContext: any = {}): any => {
-	return staticEval(ast, Object.assign({}, evalContext, formula));
+const evalExpression = (expression: string, evalContext: any = {}): any => {
+	return safeEval(expression, Object.assign({}, evalContext, formula));
 };
 
 export const evaluate = (
@@ -137,10 +137,7 @@ export const evaluate = (
 } => {
 	assert.INTERNAL(null, expression, Error, 'No expression provided');
 
-	const ast = (parse(expression).body[0] as ESTree.ExpressionStatement)
-		.expression;
-
-	const result = runAST(ast, {
+	const result = evalExpression(expression, {
 		...options.context,
 		input: options.input,
 	});
@@ -384,7 +381,7 @@ export const getTypeTriggers = (typeCard: ContractDefinition) => {
 				? ast.arguments[1]
 				: ast.arguments[0].arguments[1];
 
-		const arg = runAST(literal);
+		const arg = evalExpression(literal.raw);
 		const valueProperty = `source.${arg}`;
 
 		triggers.push(createEventsTrigger(typeCard, path, valueProperty));

--- a/package.json
+++ b/package.json
@@ -51,16 +51,16 @@
     "lodash": "^4.17.21",
     "object-deep-search": "0.0.7",
     "object-hash": "^3.0.0",
-    "static-eval": "^2.1.0"
+    "safe-eval": "^0.4.1"
   },
   "devDependencies": {
     "@balena/jellyfish-config": "^2.0.2",
     "@balena/jellyfish-types": "^2.0.4",
     "@balena/lint": "^6.2.0",
+    "@types/estree": "0.0.50",
     "@types/jest": "^27.4.1",
     "@types/json-schema": "^7.0.9",
     "@types/object-hash": "^2.2.1",
-    "@types/static-eval": "^0.2.31",
     "deplint": "^1.1.3",
     "jest": "^27.5.1",
     "lint-staged": "^12.3.5",


### PR DESCRIPTION
`static-eval` has two issues:
1) It needs an unnecessary object check when writing a callback parameter. I have raised an issue about it at [the repo](https://github.com/browserify/static-eval/issues/38).
2) It does not support arrow functions.

`safe-eval` solves both of these issues. It works a bit differently, it takes the string expression rather than an ast expression. I still kept the esprima, estree packages, as they are useful for identifying the semantics of the expression (what type it is, arguments, etc) which the existing code needs.

Change-type: minor
Signed-off-by: Stathis Moraitidis <stathis@balena.io>