### PR TITLE
Make AGGREGATE behave consistently

### DIFF
--- a/@types/@formulajs.d.ts
+++ b/@types/@formulajs.d.ts
@@ -31,7 +31,7 @@ declare module '@formulajs/formulajs' {
 		regex: string | RegExp,
 		str: string,
 	): RegExpMatchArray | null;
-	function AGGREGATE<T>(list: T[], func: (item: T) => Iterable<T>): T[];
+	function AGGREGATE<T>(list: T[], path: string): T[];
 	function ORDER_BY<T>(
 		collection: List<T> | null | undefined,
 		iteratees?: Many<ListIterator<T, NotVoid>>,

--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -132,23 +132,20 @@ test('UNIQUE(FLATMAP()): should aggregate a set of object properties', () => {
 
 describe('AGGREGATE', () => {
 	test('should ignore duplicates', () => {
-		const result = evaluate(
-			'AGGREGATE(input, PARTIAL(FLIP(PROPERTY), "mentions"))',
-			{
-				context: {},
-				input: [
-					{
-						mentions: ['foo', 'bar'],
-					},
-					{
-						mentions: ['bar', 'baz'],
-					},
-					{
-						mentions: ['baz', 'qux'],
-					},
-				],
-			},
-		);
+		const result = evaluate('AGGREGATE(input, "mentions")', {
+			context: {},
+			input: [
+				{
+					mentions: ['foo', 'bar'],
+				},
+				{
+					mentions: ['bar', 'baz'],
+				},
+				{
+					mentions: ['baz', 'qux'],
+				},
+			],
+		});
 
 		expect(result).toEqual({
 			value: ['foo', 'bar', 'baz', 'qux'],
@@ -156,20 +153,17 @@ describe('AGGREGATE', () => {
 	});
 
 	test('should aggregate a set of object properties', () => {
-		const result = evaluate(
-			'AGGREGATE(input, PARTIAL(FLIP(PROPERTY), "mentions"))',
-			{
-				context: {},
-				input: [
-					{
-						mentions: ['foo'],
-					},
-					{
-						mentions: ['bar'],
-					},
-				],
-			},
-		);
+		const result = evaluate('AGGREGATE(input, "mentions")', {
+			context: {},
+			input: [
+				{
+					mentions: ['foo'],
+				},
+				{
+					mentions: ['bar'],
+				},
+			],
+		});
 
 		expect(result).toEqual({
 			value: ['foo', 'bar'],

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -51,16 +51,8 @@ formula.REGEX_MATCH = (
 	return str.match(regex);
 };
 
-formula.AGGREGATE = <T>(list: T[], func: (item: T) => Iterable<T>): T[] => {
-	return Array.from(
-		list.reduce((accumulator, element) => {
-			for (const value of func(element)) {
-				accumulator.add(value);
-			}
-
-			return accumulator;
-		}, new Set<T>()),
-	);
+formula.AGGREGATE = <T>(list: any[], path: string): T[] => {
+	return _.uniq(_.flatMap(list, path));
 };
 
 formula.NEEDS_ALL = (...statuses: NEEDS_STATUS[]) => {


### PR DESCRIPTION
Previously, the behaviour of AGGREGATE would be different when called
using the $events special value, or when it was called in another
formula. This change makes the default AGGREGATE behaviour the same as
when it is handled as a special case with $events.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>