### PR TITLE
Improve the error message thrown by evaluate()

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -30,6 +30,15 @@ describe('.evaluate()', () => {
 		});
 	});
 
+	test.only('should throw an error if the formula is bugged', () => {
+		expect(() =>
+			evaluate('FOOBAR(input, 2', {
+				context: {},
+				input: 1,
+			}),
+		).toThrow();
+	});
+
 	test('should resolve a number formula', () => {
 		const result = evaluate('!input', {
 			context: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -129,28 +129,31 @@ export const evaluate = (
 } => {
 	assert.INTERNAL(null, expression, Error, 'No expression provided');
 
-	const ast = (parse(expression).body[0] as ESTree.ExpressionStatement)
-		.expression;
+	try {
+		const ast = (parse(expression).body[0] as ESTree.ExpressionStatement)
+			.expression;
 
-	const result = runAST(ast, {
-		...options.context,
-		input: options.input,
-	});
+		const result = runAST(ast, {
+			...options.context,
+			input: options.input,
+		});
 
-	if (_.isError(result)) {
+		if (result === undefined) {
+			return {
+				value: null,
+			};
+		}
+
 		return {
-			value: null,
+			value: result,
 		};
+	} catch (error: any) {
+		// If we hit an error parsing or running the expression
+		// throw a more useful error message
+		throw new Error(
+			`Encountered error whilst evaluating formula expression: ${expression}\n${error.message}`,
+		);
 	}
-	if (result === undefined) {
-		return {
-			value: null,
-		};
-	}
-
-	return {
-		value: result,
-	};
 };
 
 const getDefaultValueForType = (type: string): null | [] => {


### PR DESCRIPTION
The error message now includes the reason the evaluation failed and the
formula expression that was being evaluated.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>