### PR TITLE
Ignore empty evaluate results

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -770,6 +770,37 @@ describe('.evaluateObject()', () => {
 			},
 		});
 	});
+
+	test('should ignore empty array results', () => {
+		const result = evaluateObject(
+			{
+				type: 'object',
+				properties: {
+					tags: {
+						type: 'array',
+						items: {
+							type: 'string',
+						},
+						$$formula:
+							'AGGREGATE(FILTER(contract.links["has attached element"], function (c) { return c && c.type && c.type !== "create@1.0.0" && c.type !== "update@1.0.0" }), "tags")',
+					},
+					links: {},
+				},
+			},
+			{
+				tags: ['foo', 'bar'],
+				links: {
+					'has attached element': [
+						{
+							tags: [],
+						},
+					],
+				},
+			},
+		);
+
+		expect(result.tags).toEqual(['foo', 'bar']);
+	});
 });
 
 describe('NEEDS', () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -237,7 +237,12 @@ export const evaluateObject = <T extends JSONSchema7Object>(
 			input,
 		});
 
-		if (!_.isNull(result.value)) {
+		// Ignore empty/null results
+		if (
+			!_.isNull(result.value) &&
+			_.isArray(result.value) &&
+			!_.isEmpty(result.value)
+		) {
 			// Mutates input object
 			_.set(object, path.output, result.value);
 		}


### PR DESCRIPTION
AGGREGATE now returns an empty array for cases
in which it used to return undefined. We need
to ignore these empty arrays so we don't
overwrite important data with them.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Or we might instead should update [this formula](https://github.com/product-os/jellyfish-core/blob/master/lib/contracts/mixins/with-events.ts#L4) to return null when an empty array is found and not change anything in jellyscript itself.