### PR TITLE
Allow AGGREGATE to accept an initial value

### DIFF
--- a/@types/@formulajs.d.ts
+++ b/@types/@formulajs.d.ts
@@ -31,7 +31,7 @@ declare module '@formulajs/formulajs' {
 		regex: string | RegExp,
 		str: string,
 	): RegExpMatchArray | null;
-	function AGGREGATE<T>(list: T[], path: string): T[];
+	function AGGREGATE<T>(list: T[], path: string, initial: any): T[];
 	function ORDER_BY<T>(
 		collection: List<T> | null | undefined,
 		iteratees?: Many<ListIterator<T, NotVoid>>,

--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -217,6 +217,72 @@ describe('AGGREGATE', () => {
 			value: ['foo', 'bar'],
 		});
 	});
+
+	test('should accept an initial value', () => {
+		const result = evaluate('AGGREGATE(input, "mentions", source)', {
+			context: {
+				source: ['baz'],
+			},
+			input: [
+				{
+					mentions: ['foo'],
+				},
+				{
+					mentions: ['bar'],
+				},
+			],
+		});
+
+		expect(result).toEqual({
+			value: ['baz', 'foo', 'bar'],
+		});
+	});
+
+	test("should accept an initial value that isn't an array", () => {
+		const result = evaluate('AGGREGATE(input, "mentions", source)', {
+			context: {
+				source: 'baz',
+			},
+			input: [
+				{
+					mentions: ['foo'],
+				},
+				{
+					mentions: ['bar'],
+				},
+			],
+		});
+
+		expect(result).toEqual({
+			value: ['baz', 'foo', 'bar'],
+		});
+	});
+
+	test('should just return the initial value as an array if input is empty', () => {
+		const result = evaluate('AGGREGATE(input, "mentions", source)', {
+			context: {
+				source: 'baz',
+			},
+			input: [],
+		});
+
+		expect(result).toEqual({
+			value: ['baz'],
+		});
+	});
+
+	test('should just return the initial value if input is missing', () => {
+		const result = evaluate('AGGREGATE(input, "mentions", source)', {
+			context: {
+				source: 'baz',
+			},
+			input: null,
+		});
+
+		expect(result).toEqual({
+			value: ['baz'],
+		});
+	});
 });
 
 describe('REGEX_MATCH', () => {
@@ -769,6 +835,37 @@ describe('.evaluateObject()', () => {
 				number: 13,
 			},
 		});
+	});
+
+	test('should merge arrays when using AGGREGATE', () => {
+		const result = evaluateObject(
+			{
+				type: 'object',
+				properties: {
+					tags: {
+						type: 'array',
+						items: {
+							type: 'string',
+						},
+						$$formula:
+							'AGGREGATE(contract.links["has attached element"], "tags", input)',
+					},
+					links: {},
+				},
+			},
+			{
+				tags: ['foo', 'bar'],
+				links: {
+					'has attached element': [
+						{
+							tags: ['baz'],
+						},
+					],
+				},
+			},
+		);
+
+		expect(result.tags).toEqual(['foo', 'bar', 'baz']);
 	});
 });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -51,8 +51,22 @@ formula.REGEX_MATCH = (
 	return str.match(regex);
 };
 
-formula.AGGREGATE = <T>(list: any[], path: string): T[] => {
-	return _.uniq(_.without(_.flatMap(list, path), undefined));
+formula.AGGREGATE = <T>(list: any[], path: string, initial: any): T[] => {
+	if (!path) {
+		throw new Error('Cannot run AGGREGATE without a path');
+	}
+	// 1. get the current value and default to an empty array
+	const current: T[] = _.castArray(initial || []);
+	// 2. get the list of values to aggregate
+	const values = current.concat(_.flatMap(list || [], path));
+	// 3. If there aren't any values, leave the input unchanged
+	if (values.length === 0) {
+		return initial;
+	}
+	// 4. Create a unique list of values, excluding any that are undefined
+	const result: any = _.uniq(_.without(values, undefined));
+
+	return result;
 };
 
 formula.NEEDS_ALL = (...statuses: NEEDS_STATUS[]) => {


### PR DESCRIPTION
With this change, can now to provide an initial value to the AGGREGATE function.
This change allows us to transition from using the special case handling of AGGREGATE, via a `triggered-action` and `action-set-add`, to an entirely formula based solution.